### PR TITLE
Make -O3 builds by default and provide a simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: all build build-debug clean clean-build clean-venv test
+
+all: build venv
+	@:
+
+build: venv
+	DEBUG=$(DEBUG) venv/bin/python3 setup.py build_ext --inplace
+
+build-debug: override DEBUG=1
+build-debug: build ;
+
+clean: clean-venv clean-build
+	@:
+
+clean-venv:
+	rm -rf venv
+
+clean-build:
+	rm -rf build
+
+test: build
+	venv/bin/pytest
+
+venv:
+	python3 -mvenv venv
+	venv/bin/pip install setuptools Cython uwcwidth pytest

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,31 @@
 # (C) 2024 !ZAJC!/GDS
 # SPDX-License-Identifier: 0BSD
+import os
+import platform
+
 from setuptools import setup, Extension
+
+
+DEBUG=(os.getenv('DEBUG') or '').strip().lower() in ['1', 'y', 'true']
+MSVC=(platform.platform().startswith('Windows') and
+      platform.python_compiler().startswith('MS'))
+COMPILE_ARGS=[] if MSVC else (["-g", "-O0", "-UNDEBUG"] if DEBUG else ["-O3"])
+
+
+def ugrapheme_ext(module, pyx_file):
+    return Extension(module,
+                     sources=[pyx_file],
+                     extra_compile_args=COMPILE_ARGS)
+
 
 setup(
     name='ugrapheme',
-    ext_modules=[Extension("ugrapheme.alloc", sources=["ugrapheme/alloc.pyx"]),
-                 Extension("ugrapheme.graphemes", sources=["ugrapheme/graphemes.pyx"]),
-                 Extension("ugrapheme.iterate", sources=["ugrapheme/iterate.pyx"]),
-                 Extension("ugrapheme.offsets", sources=["ugrapheme/offsets.pyx"]),
-                 Extension("ugrapheme.justify", sources=["ugrapheme/justify.pyx"]),
-                 Extension("ugrapheme.ugrapheme", sources=["ugrapheme/ugrapheme.pyx"])],
+    ext_modules=[ugrapheme_ext("ugrapheme.alloc", "ugrapheme/alloc.pyx"),
+                 ugrapheme_ext("ugrapheme.graphemes", "ugrapheme/graphemes.pyx"),
+                 ugrapheme_ext("ugrapheme.iterate", "ugrapheme/iterate.pyx"),
+                 ugrapheme_ext("ugrapheme.offsets", "ugrapheme/offsets.pyx"),
+                 ugrapheme_ext("ugrapheme.justify", "ugrapheme/justify.pyx"),
+                 ugrapheme_ext("ugrapheme.ugrapheme", "ugrapheme/ugrapheme.pyx")],
     package_data={'ugrapheme': ['*.pxd', '*.pyx', 'tables/*.pxd', 'tables/*.pyx']},
     include_package_data=True
 )


### PR DESCRIPTION
It turns out that on some Linux distributions, build_ext will not build with optimizations on by default, making ugrapheme 4x slower.

Provide a simple Makefile to help contributors/maintainers/forkers, and massage setuptools to include debug and optimization flags while hopefully not messing with MSVC (which uses different flags).